### PR TITLE
actions/cache@v2 -> v4: v2 is deprecated

### DIFF
--- a/lib/ort-2.0.0-rc.4/.github/workflows/code-quality.yml
+++ b/lib/ort-2.0.0-rc.4/.github/workflows/code-quality.yml
@@ -61,7 +61,7 @@ jobs:
         id: rust-version
         run: echo "::set-output name=version::$(cargo --version | cut -d ' ' -f 2)"
         shell: bash
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: tarpaulin-cache
         with:
           path: ~/.cargo/bin/cargo-tarpaulin


### PR DESCRIPTION
Ref: https://github.com/neondatabase/cloud/issues/21508

(c) https://github.com/actions/cache/commit/faf639248d95d2a6c5884b8e6588e233eb3b10a0
⚠️ Important changes

The cache backend service has been rewritten from the ground up for improved performance and reliability. [actions/cache](https://github.com/actions/cache) now integrates with the new cache service (v2) APIs.

The new service will gradually roll out as of February 1st, 2025. The legacy service will also be sunset on the same date. Changes in these release are fully backward compatible.

We are deprecating some versions of this action. We recommend upgrading to version v4 or v3 as soon as possible before February 1st, 2025. (Upgrade instructions below).

If you are using pinned SHAs, please use the SHAs of versions v4.2.0 or v3.4.0