### PR TITLE
Change wait_latch to a zero timeout to poll instead of blocking.

### DIFF
--- a/exts/rag_bge_small_en_v15/src/lib.rs
+++ b/exts/rag_bge_small_en_v15/src/lib.rs
@@ -166,6 +166,7 @@ pub extern "C-unwind" fn background_main(arg: pg_sys::Datum) {
             Server::builder()
                 .add_service(EmbeddingGeneratorServer::new(embedder))
                 .serve_with_incoming_shutdown(uds_stream, async {
+                    // wait_latch is not an async function and does not suspend
                     while BackgroundWorker::wait_latch(Some(Duration::from_secs(0))) {
                         // suspend so that other asyncs/threads can run
                         sleep(Duration::from_millis(500)).await;

--- a/exts/rag_bge_small_en_v15/src/lib.rs
+++ b/exts/rag_bge_small_en_v15/src/lib.rs
@@ -18,7 +18,7 @@ use rayon::{ThreadPool, ThreadPoolBuilder};
 use std::{fs, os::unix::fs::PermissionsExt, sync::OnceLock};
 use tokio::{
     net::UnixListener,
-    time::Duration,
+    time::{sleep, Duration},
 };
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::{transport::Server, Request, Response, Status};
@@ -166,7 +166,8 @@ pub extern "C-unwind" fn background_main(arg: pg_sys::Datum) {
             Server::builder()
                 .add_service(EmbeddingGeneratorServer::new(embedder))
                 .serve_with_incoming_shutdown(uds_stream, async {
-                    while BackgroundWorker::wait_latch(None) {
+                    while BackgroundWorker::wait_latch(Some(Duration::from_secs(0))) {
+                        sleep(Duration::from_millis(500)).await;
                     }
                 })
                 .await

--- a/exts/rag_bge_small_en_v15/src/lib.rs
+++ b/exts/rag_bge_small_en_v15/src/lib.rs
@@ -167,6 +167,7 @@ pub extern "C-unwind" fn background_main(arg: pg_sys::Datum) {
                 .add_service(EmbeddingGeneratorServer::new(embedder))
                 .serve_with_incoming_shutdown(uds_stream, async {
                     while BackgroundWorker::wait_latch(Some(Duration::from_secs(0))) {
+                        // suspend so that other asyncs/threads can run
                         sleep(Duration::from_millis(500)).await;
                     }
                 })

--- a/exts/rag_jina_reranker_v1_tiny_en/src/lib.rs
+++ b/exts/rag_jina_reranker_v1_tiny_en/src/lib.rs
@@ -17,7 +17,7 @@ use reranking::{
 use std::{fs, os::unix::fs::PermissionsExt, sync::OnceLock};
 use tokio::{
     net::UnixListener,
-    time::Duration,
+    time::{sleep, Duration},
 };
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::{transport::Server, Request, Response, Status};
@@ -170,7 +170,8 @@ pub extern "C-unwind" fn background_main(arg: pg_sys::Datum) {
             Server::builder()
                 .add_service(RerankerServer::new(reranker))
                 .serve_with_incoming_shutdown(uds_stream, async {
-                    while BackgroundWorker::wait_latch(None) {
+                    while BackgroundWorker::wait_latch(Some(Duration::from_secs(0))) {
+                        sleep(Duration::from_millis(500)).await;
                     }
                 })
                 .await

--- a/exts/rag_jina_reranker_v1_tiny_en/src/lib.rs
+++ b/exts/rag_jina_reranker_v1_tiny_en/src/lib.rs
@@ -170,6 +170,7 @@ pub extern "C-unwind" fn background_main(arg: pg_sys::Datum) {
             Server::builder()
                 .add_service(RerankerServer::new(reranker))
                 .serve_with_incoming_shutdown(uds_stream, async {
+                    // wait_latch is not an async function and does not suspend
                     while BackgroundWorker::wait_latch(Some(Duration::from_secs(0))) {
                         // suspend so that other asyncs/threads can run
                         sleep(Duration::from_millis(500)).await;

--- a/exts/rag_jina_reranker_v1_tiny_en/src/lib.rs
+++ b/exts/rag_jina_reranker_v1_tiny_en/src/lib.rs
@@ -171,6 +171,7 @@ pub extern "C-unwind" fn background_main(arg: pg_sys::Datum) {
                 .add_service(RerankerServer::new(reranker))
                 .serve_with_incoming_shutdown(uds_stream, async {
                     while BackgroundWorker::wait_latch(Some(Duration::from_secs(0))) {
+                        // suspend so that other asyncs/threads can run
                         sleep(Duration::from_millis(500)).await;
                     }
                 })


### PR DESCRIPTION
Rust async uses cooperative multitasking. An async has to suspend (yield the CPU) to give other asyncs a chance to run. The call to wait_latch is not async, and will not yield, so it will not give other asyncs a chance to run while it is waiting. Instead of just calling wait_latch and blocking, call wait latch with an immediate timeout, then sleep for 500 milliseconds in order to yield the CPU for other tasks. This has the effect of polling the latch every 500ms instead of blocking.