### PR TITLE
Elizabeth/disable sigterm in child threads

### DIFF
--- a/exts/rag_bge_small_en_v15/src/lib.rs
+++ b/exts/rag_bge_small_en_v15/src/lib.rs
@@ -140,6 +140,7 @@ pub extern "C-unwind" fn background_main(arg: pg_sys::Datum) {
         .build()
         .expect_or_pg_err("Couldn't build tokio runtime for server")
         .block_on(async {
+            unsafe { pg_sys::BackgroundWorkerBlockSignals() };
             let path = socket_path!(pid);
             fs::remove_file(&path).unwrap_or_default(); // it's not an error if the file isn't there
             let uds = UnixListener::bind(&path).expect_or_pg_err(&format!("Couldn't create socket at {}", &path));
@@ -166,10 +167,13 @@ pub extern "C-unwind" fn background_main(arg: pg_sys::Datum) {
             Server::builder()
                 .add_service(EmbeddingGeneratorServer::new(embedder))
                 .serve_with_incoming_shutdown(uds_stream, async {
+                    unsafe { pg_sys::BackgroundWorkerUnblockSignals() };
                     // wait_latch is not an async function and does not suspend
                     while BackgroundWorker::wait_latch(Some(Duration::from_secs(0))) {
+                        unsafe { pg_sys::BackgroundWorkerBlockSignals() };
                         // suspend so that other asyncs/threads can run
                         sleep(Duration::from_millis(500)).await;
+                        unsafe { pg_sys::BackgroundWorkerUnblockSignals() };
                     }
                 })
                 .await

--- a/exts/rag_jina_reranker_v1_tiny_en/src/lib.rs
+++ b/exts/rag_jina_reranker_v1_tiny_en/src/lib.rs
@@ -22,8 +22,6 @@ use tokio::{
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::{transport::Server, Request, Response, Status};
 
-use nix::sys::signal::{self, Signal};
-
 // macros
 
 mconst!(ext_name, "rag_jina_reranker_v1_tiny_en");


### PR DESCRIPTION
There are different threads running in the rag background workers. Only the main thread should receive the SIGTERM signal because the signal handler for it has an assert that checks for this condition, and that signal handler is part of the BackgroundWorker module. So disable signals before creating/running any new threads, and re-enable them only when we poll wait_latch. Signals received while other threads are active (and have signals blocked) will set the signals to pending, and they will be delivered once we poll. The async that polls wait_latch is tied to the thread where it was created, and that is safe to run the SIGTERM signal handler from pgrx v0.14.1.