### PR TITLE
bumped pgrx to 0.16.1 and added pg18 beta2 support

### DIFF
--- a/exts/rag/Cargo.toml
+++ b/exts/rag/Cargo.toml
@@ -17,13 +17,14 @@ pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
 pg_test = []
 
 [dependencies]
 docx-rust = "0.1.8"
 htmd = "0.1.6"
 pdf-extract = "0.7.7"
-pgrx = "0.14.1"
+pgrx = "0.16.0"
 serde = "1.0.209"
 serde_json = "1.0.120"
 text-splitter = { version = "0.14.1" }
@@ -31,7 +32,7 @@ unicode-normalization = "0.1.24"
 ureq = { version = "2.9.7", features = ["json"] }
 
 [dev-dependencies]
-pgrx-tests = "0.14.1"
+pgrx-tests = "0.16.0"
 
 [profile.dev]
 panic = "unwind"

--- a/exts/rag_bge_small_en_v15/Cargo.toml
+++ b/exts/rag_bge_small_en_v15/Cargo.toml
@@ -17,6 +17,7 @@ pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18" ]
 pg_test = []
 remote_onnx = []
 
@@ -25,7 +26,7 @@ fastembed = "=3.14.1"
 tokenizers = "0.19.1"
 text-splitter = { version = "0.14.1", features = ["tokenizers"] }
 serde_json = "1.0.120"
-pgrx = "0.14.1"
+pgrx = "0.16.0"
 tonic = "0.12.3"
 prost = "0.13.3"
 tokio = "1.40.0"
@@ -45,7 +46,7 @@ ort-sys = { path = "../../lib/ort-2.0.0-rc.4/ort-sys" }
 tonic-build = "0.12.3"
 
 [dev-dependencies]
-pgrx-tests = "0.14.1"
+pgrx-tests = "0.16.0"
 
 [profile.dev]
 panic = "unwind"

--- a/exts/rag_jina_reranker_v1_tiny_en/Cargo.toml
+++ b/exts/rag_jina_reranker_v1_tiny_en/Cargo.toml
@@ -17,12 +17,13 @@ pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18" ]
 pg_test = []
 remote_onnx = []
 
 [dependencies]
 fastembed = "=3.14.1"
-pgrx = "0.14.1"
+pgrx = "0.16.0"
 tonic = "0.12.3"
 prost = "0.13.3"
 tokio = "1.40.0"
@@ -42,7 +43,7 @@ ort-sys = { path = "../../lib/ort-2.0.0-rc.4/ort-sys" }
 tonic-build = "0.12.3"
 
 [dev-dependencies]
-pgrx-tests = "0.14.1"
+pgrx-tests = "0.16.0"
 
 [profile.dev]
 panic = "unwind"


### PR DESCRIPTION
We need support for pgrx 0.16.1 to support pg18 beta2. This PR bumps the pgrx version and fixes all breaking changes introduced since pgrx 0.12.6